### PR TITLE
GitHub Action to publish releases to Firefox

### DIFF
--- a/.github/workflows/Publish extensions.yml
+++ b/.github/workflows/Publish extensions.yml
@@ -1,0 +1,51 @@
+name: Publish to extension store
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  create_zip:
+    runs-on: ubuntu-latest
+    outputs:
+      guid: ${{ steps.guid.outputs.GECKO_GUID }}
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set env variables 
+        id: guid
+        run: |
+          echo "GECKO_GUID=$(jq -r '.browser_specific_settings.gecko.id' manifest.json)" >> $GITHUB_OUTPUT
+      
+      - name: Make zip file
+        run: zip -r ClintonCAT.zip *
+
+      - name: Upload archive as artifact
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: ClintonCAT.zip
+          path: ClintonCAT.zip
+
+  firefox_publish:
+    runs-on: ubuntu-latest
+    needs: create_zip
+    steps:
+    - name: Download prepared archive
+      uses: actions/download-artifact@v4.1.8
+      with:
+        name: ClintonCAT.zip
+
+    - name: Set GUID env variable
+      run: echo "GUID=${{needs.create_zip.outputs.GECKO_GUID}}" >> $GITHUB_ENV
+      
+    - uses: wdzeng/firefox-addon@v1
+      with:
+        addon-guid: ${{ env.GUID }}
+        xpi-path: ClintonCAT.zip
+        self-hosted: false
+        approval-notes: "The extension source can be found at https://github.com/WayneKeenan/ClintonCAT"
+        jwt-issuer: ${{ secrets.FIREFOX_JWT_ISSUER }}
+        jwt-secret: ${{ secrets.FIREFOX_JWT_SECRET }}

--- a/.github/workflows/Publish extensions.yml
+++ b/.github/workflows/Publish extensions.yml
@@ -8,7 +8,7 @@ jobs:
   create_zip:
     runs-on: ubuntu-latest
     outputs:
-      guid: ${{ steps.guid.outputs.GECKO_GUID }}
+      GECKO_GUID: ${{ steps.guid.outputs.GECKO_GUID }}
     steps:
       - name: Checkout release source
         uses: actions/checkout@v3


### PR DESCRIPTION
This requires getting API keys from [here](https://addons.mozilla.org/en-US/developers/addon/api/key/) then using them [here](https://github.com/WayneKeenan/ClintonCAT/settings/secrets/actions). They should be called `FIREFOX_JWT_ISSUER` and `FIREFOX_JWT_SECRET`. 
Ideally it would match the version number in `manifest.json` to the version in the release tag, but I have no idea how anyone actually uses GitHub Actions with how messy they are.

It should be easy to add support for publishing to [Chrome](https://github.com/marketplace/actions/publish-chrome-extension) and [Edge](https://github.com/marketplace/actions/publish-edge-add-on). 