### PR TITLE
automatic background updates

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Clinton CAT",
   "version": "1.0",
   "description": "Search Rossmann's Consumer Action Taskforce (CAT) wiki for the site being visited",
-  "permissions": ["scripting", "activeTab", "storage"],
+  "permissions": ["scripting", "activeTab", "storage", "alarms"],
   "host_permissions": ["<all_urls>"],
   "background": {
     "service_worker": "background.js",

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,6 @@
   "host_permissions": ["<all_urls>"],
   "background": {
     "service_worker": "background.js",
-    "scripts": ["background.js"],
     "type": "module"
   },
   "content_scripts": [


### PR DESCRIPTION
Partially solving #25

- Adds alarms permissions
- Removes scripts entry to prevent double execution
- Add logic to periodically update the cached pagesDb via the chrome.storage.local api

- [ ] Needs testing in firefox