### PR TITLE
bug: Workflow conditional release and bump versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build and Publish ClintonCAT
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -14,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
 
@@ -31,7 +32,8 @@ jobs:
         run: zip -r clintoncat-extension.zip dist/*
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           files: clintoncat-extension.zip
         env:


### PR DESCRIPTION
Now using latest actions version and creating a release only when a tag is pushed