### PR TITLE
feat: Implemented ValueListeners for preferences

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,6 +40,12 @@ export default tseslint.config(
     },
     includeIgnoreFile(gitignorePath),
     {
-        ignores: ["**/webpack.config.js", "**/eslint.config.mjs"],
+        ignores: [
+            "**/webpack.config.js",
+            "**/eslint.config.mjs",
+            "**/jest.config.ts",
+            "**/webpack-plugins",
+            "**/scripts",
+        ],
     }
 );

--- a/src/domhelper.ts
+++ b/src/domhelper.ts
@@ -203,7 +203,7 @@ export class DOMHelper implements IDOMHelperInterface {
                         const newElement = document.createElement(message.element);
                         console.log('DOM_CREATE_ELEMENT html: ', message.html);
 
-                        newElement.innerHTML = message.html;
+                        newElement.innerHTML = (message.html ?? '');
                         try {
                             parent.appendChild(newElement);
                         } catch (error) {

--- a/src/listeners.ts
+++ b/src/listeners.ts
@@ -1,0 +1,186 @@
+export class SortedArray<T> {
+    private _values: T[] = [];
+
+    constructor(...values: T[]) {
+        this.value = values;
+    }
+
+    private _searchIndex(value: T): number {
+        let l = 0;
+        let r = this._values.length;
+        while (l < r) {
+            const mid = ((l + r) / 2) >> 0;
+            if (value === this._values[mid]) {
+                return mid;
+            } else if (value < this._values[mid]) {
+                r = mid;
+            } else {
+                l = mid + 1;
+            }
+        }
+        return r;
+    }
+
+    get length(): number {
+        return this._values.length;
+    }
+
+    get value(): T[] {
+        return this._values;
+    }
+
+    set value(values: T[]) {
+        this._values = values;
+        this._values.sort();
+    }
+
+    add(value: T) {
+        const idx = this._searchIndex(value);
+        this._values.splice(idx, 0, value);
+    }
+
+    deleteAt(i: number) {
+        this._values.splice(i, 1);
+    }
+
+    delete(value: T): boolean {
+        const idx = this._searchIndex(value);
+        if (this._values[idx] == value) {
+            this.deleteAt(idx);
+            return true;
+        }
+        return false;
+    }
+
+    clear() {
+        this._values = [];
+    }
+}
+
+interface Printable {
+    toString(): string;
+}
+
+export type ResultCallback<T> = (result: T) => void;
+
+export interface IListener<T> {
+    value: T;
+    callbacks: Map<string, ResultCallback<T>>;
+    addListener(id: string, callback: ResultCallback<T>): void;
+    removeListener(id: string): void;
+    removeAllListeners(): void;
+}
+
+export class ValueListener<T extends Printable> implements IListener<T> {
+    private _value: T;
+    private _callbacks: Map<string, ResultCallback<T>>;
+
+    constructor(value: T) {
+        this._value = value;
+        this._callbacks = new Map();
+    }
+
+    get value(): T {
+        return this._value;
+    }
+
+    set value(val: T) {
+        this._value = val;
+        this.makeCallbacks();
+    }
+
+    get callbacks(): Map<string, ResultCallback<T>> {
+        return this._callbacks;
+    }
+
+    private makeCallbacks() {
+        for (const callback of this._callbacks.values()) {
+            callback(this._value);
+        }
+    }
+
+    addListener(id: string, callback: ResultCallback<T>) {
+        this._callbacks.set(id, callback);
+    }
+
+    removeListener(id: string) {
+        this._callbacks.delete(id);
+    }
+
+    removeAllListeners() {
+        this._callbacks.clear();
+    }
+
+    toString(): string {
+        return this._value.toString();
+    }
+}
+
+export class OrderedSetListener<T extends Printable> implements IListener<T[]> {
+    private _seen: Set<T>;
+    private _value: SortedArray<T>;
+    private _callbacks: Map<string, ResultCallback<T[]>>;
+
+    constructor(...values: T[]) {
+        this._value = new SortedArray(...values);
+        this._seen = new Set(this._value.value);
+        this._callbacks = new Map();
+    }
+
+    get value(): T[] {
+        return this._value.value;
+    }
+
+    set value(val: T[]) {
+        this._value.value = val;
+        this._seen = new Set(val);
+        this.makeCallbacks();
+    }
+
+    get callbacks(): Map<string, ResultCallback<T[]>> {
+        return this._callbacks;
+    }
+
+    add(elem: T) {
+        if (!this._seen.has(elem)) {
+            this._value.add(elem);
+            this._seen.add(elem);
+            this.makeCallbacks();
+        }
+    }
+
+    deleteAt(index: number) {
+        this._seen.delete(this.value[index]);
+        this._value.deleteAt(index);
+        this.makeCallbacks();
+    }
+
+    delete(elem: T) {
+        this._seen.delete(elem);
+        if (this._value.delete(elem)) {
+            this.makeCallbacks();
+        }
+    }
+
+    private makeCallbacks() {
+        for (const callback of this._callbacks.values()) {
+            callback(this.value);
+        }
+    }
+
+    addListener(id: string, callback: ResultCallback<T[]>) {
+        this._callbacks.set(id, callback);
+    }
+
+    removeListener(id: string) {
+        this._callbacks.delete(id);
+    }
+
+    removeAllListeners() {
+        this._callbacks.clear();
+    }
+
+    toString(): string {
+        return this._value.value.toString();
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ export class Main {
 
     indicateStatus() {
         void chrome.action.setBadgeText({
-            text: Preferences.isEnabled ? 'on' : 'off',
+            text: Preferences.isEnabled.value ? 'on' : 'off',
         });
     }
 
@@ -41,7 +41,7 @@ export class Main {
     }
 
     checkDomainIsExcluded(domain: string): boolean {
-        return this.domainTools.isDomainExcluded(Preferences.domainExclusions, domain);
+        return this.domainTools.isDomainExcluded(Preferences.domainExclusions.value, domain);
     }
 
     async onPageLoaded(domain: string, url: string): Promise<void> {
@@ -81,7 +81,7 @@ export class Main {
 
             if (message.badgeText) {
                 this.onBadgeTextUpdate(message.badgeText);
-            } else if (!Preferences.isEnabled) {
+            } else if (!Preferences.isEnabled.value) {
                 this.indicateStatus();
             } else if (message.domain) {
                 await this.onPageLoaded(message.domain, message.url);

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -6,27 +6,28 @@ import './options.css';
 const Options: React.FC = () => {
     const [items, setItems] = useState<string[]>([]);
     const [input, setInput] = useState('');
+    Preferences.init();
+    Preferences.domainExclusions.addListener('exclude-options', (result: string[]) => {
+        setItems([...result]); // Forces UI update: https://stackoverflow.com/questions/69836737/react-state-is-not-updating-the-ui
+    });
 
     useEffect(() => {
-        setItems(Preferences.domainExclusions);
+        setItems(Preferences.domainExclusions.value);
     }, []);
 
     const addItem = () => {
         if (input.trim() !== '') {
-            setItems([...items, input]);
-            Preferences.domainExclusions = items;
+            Preferences.domainExclusions.add(input.trim());
             setInput('');
         }
     };
 
     const removeItem = (index: number) => {
-        setItems(items.filter((_, i) => i !== index));
-        Preferences.domainExclusions = items;
+        Preferences.domainExclusions.deleteAt(index);
     };
 
     const clearList = () => {
-        Preferences.domainExclusions = [];
-        setItems([]);
+        Preferences.domainExclusions.value = [];
     };
 
     return (

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,28 +1,11 @@
+import { ValueListener, OrderedSetListener } from './listeners';
+
 export class Preferences {
     static readonly IS_ENABLED_KEY = 'is_enabled';
     static readonly DOMAIN_EXCLUSIONS_KEY = 'domain_exclusions';
 
-    private static _isEnabled: boolean = true;
-
-    static get isEnabled(): boolean {
-        return this._isEnabled;
-    }
-
-    static set isEnabled(isEnabled: boolean) {
-        this._isEnabled = isEnabled;
-        void this.setPreference(Preferences.IS_ENABLED_KEY, isEnabled);
-    }
-
-    private static _domainExclusions: string[] = [];
-
-    static get domainExclusions(): string[] {
-        return this._domainExclusions;
-    }
-
-    static set domainExclusions(domains: string[]) {
-        this._domainExclusions = domains;
-        void this.setPreference(Preferences.DOMAIN_EXCLUSIONS_KEY, domains);
-    }
+    static isEnabled = new ValueListener<boolean>(true);
+    static domainExclusions = new OrderedSetListener<string>();
 
     static async refresh() {
         console.log('Refreshing settings');
@@ -30,15 +13,27 @@ export class Preferences {
         await this.getPreference(this.DOMAIN_EXCLUSIONS_KEY);
     }
 
+    static init() {
+        this.isEnabled.removeAllListeners();
+        this.isEnabled.value = true;
+        this.isEnabled.addListener(this.IS_ENABLED_KEY, (result: boolean) => {
+            void this.setPreference(Preferences.IS_ENABLED_KEY, result);
+        });
+        this.domainExclusions.removeAllListeners();
+        this.domainExclusions.value = [];
+        this.domainExclusions.addListener(this.DOMAIN_EXCLUSIONS_KEY, (result: string[]) => {
+            void this.setPreference(Preferences.DOMAIN_EXCLUSIONS_KEY, result);
+        });
+    }
+
     // eslint-disable-next-line @typescript-eslint/require-await
     static async initDefaults() {
-        console.log('Defaulting settings');
-        this.isEnabled = true;
-        this.domainExclusions = [];
+        console.log('Defaulting settings'); // TODO: Get from localStorage
+        this.init();
     }
 
     public static dump(): void {
-        const msg: string = `IsEnabled = ${Preferences._isEnabled.toString()}, DomainExclusions = ${Preferences._domainExclusions.toString()}`;
+        const msg: string = `IsEnabled = ${Preferences.isEnabled.toString()}, DomainExclusions = ${Preferences.domainExclusions.toString()}`;
         console.log(msg);
     }
 


### PR DESCRIPTION
With this PR I'm proposing a different way to handle user `Preferences`, in hope to react more easily to their modifications.

Whenever working with them one should call the `Preferences.init()` method to initialize the underling logic that ties the class with the actual localStorage access. Afterwards the developer is free to create custom callbacks that are called whenever the value that such listeners hold changes in any way (do not use the actual value's methods, otherwise callbacks won't fire, use only those defined in the Listener class).
When adding callbacks using `addListener` a string-id is required to recognize different callbacks and to remove them if needed.

Furthermore, excluded domains are now automatically sorted.

I'm open to any feedback, thanks again for your time.
