### PR TITLE
Remove temporary workaround for multi-level TLDs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -68,7 +68,7 @@ export class Main {
      * and indicates how many CAT pages were found.
      */
     async onPageLoaded(domain: string, url: string): Promise<void> {
-        const mainDomain = this.domainTools.extractMainDomain(domain);
+        const mainDomain = await this.domainTools.extractMainDomain(domain);
         console.log('Main domain:', mainDomain);
 
         if (this.checkDomainIsExcluded(mainDomain)) {

--- a/src/storagecache.ts
+++ b/src/storagecache.ts
@@ -9,6 +9,8 @@ export class StorageCache {
     static readonly FETCH_INTERVAL_MINUTES: number = 30; // Fetch every 30 minutes
     static readonly FETCH_INTERVAL_MS: number = StorageCache.FETCH_INTERVAL_MINUTES * 60 * 1000;
 
+    //TODO: Add caching for the suffix list
+
     private pagesDb: PagesDB;
     constructor(pagesDb: PagesDB) {
         this.pagesDb = pagesDb;


### PR DESCRIPTION
Changed from checking a handful of multi-level TLDs to pulling a list from publicsuffix.org.

Changed mainDomain to await so we know the list has been obtained

Thank you for your contribution to the ClintonCAT repo.
Before submitting this PR, please make sure:

- [x] The target of this PR is the `main` branch.
- [x] No commits are missing from forked base branch (e.g. modified main branch instead of dev)
- [x] All test pass, run `npm test`
- [x] The code is formated, run `npm run format`