### PR TITLE
Fixed preferences not interacting with storage

### DIFF
--- a/src/options.tsx
+++ b/src/options.tsx
@@ -3,8 +3,10 @@ import { createRoot } from 'react-dom/client';
 import * as styles from './options.module.css';
 import classNames from 'classnames';
 import Preferences from './preferences';
+import ChromeSyncStorage from './storage/chrome-sync-storage';
+import ChromeLocalStorage from './storage/chrome-local-storage';
 
-Preferences.init();
+Preferences.initDefaults(new ChromeSyncStorage(), new ChromeLocalStorage());
 
 const Options = () => {
     const [items, setItems] = useState<string[]>([]);
@@ -35,6 +37,12 @@ const Options = () => {
         Preferences.domainExclusions.value = [];
     };
 
+    const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key == 'Enter') {
+            addItem();
+        }
+    };
+
     return (
         <div className={styles.optionsPage}>
             <h1 className={styles.pageTitle}>Extension Options</h1>
@@ -47,6 +55,7 @@ const Options = () => {
                                 type="text"
                                 value={domainInput}
                                 onChange={(e) => setDomainInput(e.target.value)}
+                                onKeyDown={(event) => onKeyDown(event)}
                                 placeholder="Enter a domain"
                                 className={styles.inputField}
                             />

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -2,16 +2,20 @@ import React, { useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import * as styles from './popup.module.css';
 import Preferences from './preferences';
+import ChromeSyncStorage from './storage/chrome-sync-storage';
+import ChromeLocalStorage from './storage/chrome-local-storage';
+
+Preferences.initDefaults(new ChromeSyncStorage(), new ChromeLocalStorage());
 
 const Popup = () => {
-    const [isEnabled, setIsEnabled] = useState(false);
+    const [isEnabled, setIsEnabled] = useState(Preferences.isEnabled.value);
+
+    Preferences.isEnabled.addListener('enable-options', (result: boolean) => {
+        setIsEnabled(result);
+    });
 
     const handleToggleEnabled = () => {
-        // TODO:
-        setIsEnabled(() => {
-            Preferences.isEnabled.value = !Preferences.isEnabled.value;
-            return Preferences.isEnabled.value;
-        });
+        Preferences.isEnabled.value = !Preferences.isEnabled.value;
     };
 
     const openCATPage = () => {
@@ -19,12 +23,12 @@ const Popup = () => {
     };
 
     const allowThisSite = () => {
-        // TODO:
+        const domain = window.location.hostname; // TODO: gets extension name instead of open tab domain
+        Preferences.domainExclusions.delete(domain);
     };
 
     const excludeThisSite = () => {
-        // TODO:
-        const domain = window.location.hostname;
+        const domain = window.location.hostname; // TODO: gets extension name instead of open tab domain
         Preferences.domainExclusions.add(domain);
     };
 

--- a/src/storage/chrome-local-storage.ts
+++ b/src/storage/chrome-local-storage.ts
@@ -43,8 +43,7 @@ class ChromeLocalStorage implements IStorageBackend {
                     const parsedValue = JSON.parse(rawValue) as unknown;
                     console.log(`ChromeLocalStorage.get: ${key} =>`, parsedValue);
 
-                    // only return the parsed value if it's a string
-                    return typeof parsedValue === 'string' ? resolve(parsedValue) : resolve(null);
+                    return parsedValue !== null ? resolve(parsedValue) : resolve(null);
                 } catch (_error) {
                     console.warn(
                         `ChromeLocalStorage.get: could not parse value for key '${key}'. Returning raw value as string.`

--- a/src/storage/chrome-sync-storage.ts
+++ b/src/storage/chrome-sync-storage.ts
@@ -3,7 +3,7 @@ import { IStorageBackend } from './istorage-backend';
 
 class ChromeSyncStorage implements IStorageBackend {
     /**
-     * Stores a value under the given key in chrome.storage.local.
+     * Stores a value under the given key in chrome.storage.sync.
      * The value is JSON-stringified first.
      */
     async set(key: string, value: unknown): Promise<void> {
@@ -19,7 +19,7 @@ class ChromeSyncStorage implements IStorageBackend {
     }
 
     /**
-     * Retrieves a value from chrome.storage.local for the given key.
+     * Retrieves a value from chrome.storage.sync for the given key.
      * The stored value is JSON-parsed before returning.
      */
     async get(key: string): Promise<unknown> {
@@ -28,26 +28,26 @@ class ChromeSyncStorage implements IStorageBackend {
                 if (chrome.runtime.lastError) return reject(getChromeLastError());
 
                 const rawValue: unknown = result[key];
+                console.log('Rawvalue', rawValue, typeof rawValue);
 
                 if (rawValue === undefined || rawValue === null) {
-                    console.log(`ChromeLocalStorage.get: ${key} => null`);
+                    console.log(`ChromeSyncStorage.get: ${key} => null`);
                     return resolve(null);
                 }
 
                 if (typeof rawValue !== 'string') {
-                    console.warn(`ChromeLocalStorage.get: stored value for '${key}' is not a string. Returning null.`);
+                    console.warn(`ChromeSyncStorage.get: stored value for '${key}' is not a string. Returning null.`);
                     return resolve(null);
                 }
 
                 try {
                     const parsedValue = JSON.parse(rawValue) as unknown;
-                    console.log(`ChromeLocalStorage.get: ${key} =>`, parsedValue);
+                    console.log(`ChromeSyncStorage.get: ${key} =>`, parsedValue);
 
-                    // only return the parsed value if it's a string
-                    return typeof parsedValue === 'string' ? resolve(parsedValue) : resolve(null);
+                    return parsedValue !== null ? resolve(parsedValue) : resolve(null);
                 } catch (_error) {
                     console.warn(
-                        `ChromeLocalStorage.get: could not parse value for key '${key}'. Returning raw value as string.`
+                        `ChromeSyncStorage.get: could not parse value for key '${key}'. Returning raw value as string.`
                     );
                     return resolve(rawValue);
                 }
@@ -56,13 +56,13 @@ class ChromeSyncStorage implements IStorageBackend {
     }
 
     /**
-     * Removes the given key from chrome.storage.local.
+     * Removes the given key from chrome.storage.sync.
      */
     async remove(key: string): Promise<void> {
         return new Promise((resolve, reject) => {
-            chrome.storage.local.remove(key, () => {
+            chrome.storage.sync.remove(key, () => {
                 if (chrome.runtime.lastError) return reject(getChromeLastError());
-                console.log(`ChromeLocalStorage.remove: ${key}`);
+                console.log(`ChromeSyncStorage.remove: ${key}`);
                 resolve();
             });
         });


### PR DESCRIPTION
Fixes #36.
Fixes #37.

With these changes preferences now actually persist in synced storage.
Notably I've reduced the moving parts in the `preferences.ts`, file making use of the single method `initDefaults` to achieve initialization and refreshing behaviors.

I'm open to any feedback and, once again, thank you for the amazing work you've been putting in this extension!

