### PR TITLE
Fix Webpack CopyPlugin to ensure manifest.json is always copied

### DIFF
--- a/engines/gecko/webpack.config.js
+++ b/engines/gecko/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = (env, argv) => {
         plugins: [
             ...baseConfig(env, argv).plugins,
             new CopyPlugin({
-                patterns: [{ from: 'engines/gecko/manifest.json', to: './' }],
+                patterns: [{ from: 'engines/gecko/manifest.json', to: './', force: true }],
             }),
         ],
     };


### PR DESCRIPTION
This commit fixes an issue where `manifest.json` for Firefox (Gecko) was copied with chromium specific parameters during the Webpack build process. The solution was to add `force: true` to the `CopyPlugin` configuration.
