### PR TITLE
Add system notification toggle functionality

### DIFF
--- a/src/common/services/preferences.ts
+++ b/src/common/services/preferences.ts
@@ -11,6 +11,9 @@ class Preferences {
     static isEnabled = new ObservableValue<boolean>(true);
     static domainExclusions = new ObservableSet<string>();
 
+    static readonly SHOW_SYS_NOTIFICATIONS_KEY = 'show_sys_notifications';
+    static showSysNotifications = new ObservableValue<boolean>(false);
+
     // Injected storage backends  (TODO: do we need both?)
     // Sync is used to share data across browsers if logged in, e.g. plugin settings
     // Local is for 'this' browser only storage and can have more space available, e.g. for the pages db
@@ -36,6 +39,8 @@ class Preferences {
         // Reset callbacks
         this.isEnabled.removeAllListeners();
         this.domainExclusions.removeAllListeners();
+        this.showSysNotifications.removeAllListeners();
+
         // Set up default callbacks
         this.isEnabled.addListener(this.IS_ENABLED_KEY, (result: boolean) => {
             void this.setPreference(Preferences.IS_ENABLED_KEY, result);
@@ -43,6 +48,10 @@ class Preferences {
 
         this.domainExclusions.addListener(this.DOMAIN_EXCLUSIONS_KEY, (result: string[]) => {
             void this.setPreference(Preferences.DOMAIN_EXCLUSIONS_KEY, result);
+        });
+
+        this.showSysNotifications.addListener(this.SHOW_SYS_NOTIFICATIONS_KEY, (result: boolean) => {
+            void this.setPreference(Preferences.SHOW_SYS_NOTIFICATIONS_KEY, result);
         });
 
         // Attempt preference retrieval
@@ -60,12 +69,19 @@ class Preferences {
         } else {
             this.domainExclusions.value = Preferences.DEFAULT_DOMAIN_EXCLUSIONS;
         }
+        const rawShowSysNotifications = await this.getPreference(this.SHOW_SYS_NOTIFICATIONS_KEY);
+        if (typeof rawShowSysNotifications === 'boolean') {
+            this.showSysNotifications.value = rawShowSysNotifications;
+        } else {
+            this.showSysNotifications.value = false;
+        }
     }
 
     public static dump(): void {
         const msg: string =
             `IsEnabled = ${Preferences.isEnabled.toString()}, ` +
-            `DomainExclusions = ${Preferences.domainExclusions.toString()}`;
+            `DomainExclusions = ${Preferences.domainExclusions.toString()}` +
+            `ShowSysNotifications = ${Preferences.showSysNotifications.toString()}`;
         console.log(msg);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,12 +43,14 @@ export class Main {
 
         // Example: show a notification about the found pages
         // NOTE: Requires "notifications" permission in your manifest.json
-        chrome.notifications.create({
-            type: 'basic',
-            iconUrl: 'icon48.png', // TODO: Use a proper icon
-            title: 'CAT Pages Found',
-            message: `Found ${pages.totalPagesFound.toString()} page(s).`,
-        });
+        if (Preferences.showSysNotifications.value && pages.totalPagesFound > 0) {
+            chrome.notifications.create({
+                type: 'basic',
+                iconUrl: 'icon48.png', // TODO: Use a proper icon
+                title: 'CAT Pages Found',
+                message: `Found ${pages.totalPagesFound.toString()} page(s).`,
+            });
+        }
     }
 
     /**

--- a/src/ui/options/Options.tsx
+++ b/src/ui/options/Options.tsx
@@ -12,6 +12,7 @@ const Options = () => {
     const [items, setItems] = useState<string[]>([]);
     const [domainInput, setDomainInput] = useState('');
     const [domainError, setDomainError] = useState('');
+    const [showSysNotifications, setShowSysNotifications] = useState(Preferences.showSysNotifications.value);
 
     useEffectOnce(() => {
         Preferences.initDefaults(new ChromeSyncStorage(), new ChromeLocalStorage())
@@ -19,11 +20,20 @@ const Options = () => {
                 Preferences.domainExclusions.addListener('exclude-options', (result: string[]) =>
                     setItems([...result])
                 );
+
+                Preferences.showSysNotifications.addListener('show-sys-notifications-options', (result: boolean) =>
+                    setShowSysNotifications(result)
+                );
+
                 setItems([...Preferences.domainExclusions.value]);
+                setShowSysNotifications(Preferences.showSysNotifications.value);
             })
             .catch((error: unknown) => console.error('Failed to initialize preferences:', error));
 
-        return () => Preferences.domainExclusions.removeListener('exclude-options');
+        return () => {
+            Preferences.domainExclusions.removeListener('exclude-options');
+            Preferences.showSysNotifications.removeListener('show-sys-notifications-options');
+        };
     });
 
     const addItem = () => {
@@ -49,6 +59,12 @@ const Options = () => {
     const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
         addItem();
+    };
+
+    const handleSysNotificationsToggle = () => {
+        const newValue = !showSysNotifications;
+        setShowSysNotifications(newValue);
+        Preferences.showSysNotifications.value = newValue;
     };
 
     return (
@@ -94,10 +110,13 @@ const Options = () => {
                 <div className={styles.settingsColumn}>
                     <h2 className={styles.columnTitle}>Other Settings</h2>
                     <div className={styles.settingsContainer}>
-                        <p>TODO</p>
                         <label className={styles.toggleLabel}>
-                            <span>Enable Feature XYZ</span>
-                            <input type="checkbox" />
+                            <span>Enable System Notifications</span>
+                            <input
+                                type="checkbox"
+                                checked={showSysNotifications}
+                                onChange={handleSysNotificationsToggle}
+                            />
                             <span className={styles.toggleSlider} />
                         </label>
                     </div>


### PR DESCRIPTION
Add system notification toggle to extension options (`disabled` by default) and if 0 wiki pages are found no notification is sent.