### PR TITLE
[Fix] - Update page indication and notification

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -37,18 +37,24 @@ export class Main {
      * Display how many pages were found by updating the badge text
      */
     indicateCATPages(pages: CATWikiPageSearchResults): void {
-        // Update badge text with total pages found
-        void chrome.action.setBadgeText({ text: pages.totalPagesFound.toString() });
+        const totalPages = pages.totalPagesFound;
         console.log(pages);
 
-        // Example: show a notification about the found pages
-        // NOTE: Requires "notifications" permission in your manifest.json
-        chrome.notifications.create({
-            type: 'basic',
-            iconUrl: 'icon48.png', // TODO: Use a proper icon
-            title: 'CAT Pages Found',
-            message: `Found ${pages.totalPagesFound.toString()} page(s).`,
-        });
+        if (totalPages > 0) {
+            // Update badge text with total pages found
+            void chrome.action.setBadgeText({ text: pages.totalPagesFound.toString() });
+            // Example: show a notification about the found pages
+            // NOTE: Requires "notifications" permission in your manifest.json
+            chrome.notifications.create({
+                type: 'basic',
+                iconUrl: 'icon48.png', // TODO: Use a proper icon
+                title: 'CAT Pages Found',
+                message: `Found ${pages.totalPagesFound.toString()} page(s).`,
+            });
+        } else {
+            // Revert badge text back to "on" or "off" as set by indicateStatus
+            this.indicateStatus();
+        }
     }
 
     /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ export class Main {
             // NOTE: Requires "notifications" permission in your manifest.json
             chrome.notifications.create({
                 type: 'basic',
-                iconUrl: 'icon48.png', // TODO: Use a proper icon
+                iconUrl: chrome.runtime.getURL('alert.png'),
                 title: 'CAT Pages Found',
                 message: `Found ${pages.totalPagesFound.toString()} page(s).`,
             });


### PR DESCRIPTION
## Summary
- Fix: Updated indicateCATPages method to only show page count and send notification when pages are found
     - *When no pages are found, call indicateStatus to revert the badge text to on of off*
     - *Notifications are only sent when the total pages found are more than 0*
----
- [x] The target of this PR is the `main` branch.
- [x] No commits are missing from forked base branch (e.g. modified main branch instead of dev)
- [x] You have squashed all the commits 
- [x] All test pass, run `npm test`
- [x] The code is formatted, run `npm run format`
- [x] You have updated or added test cases, as/if required
- [x] You have installed and tried out the plugin in a supported browser
