### PR TITLE
Notifications respect if extension has been disabled

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -48,7 +48,7 @@ export class Main {
             // Update badge text with total pages found
             void browser.action.setBadgeText({ text: pages.totalPagesFound.toString() });
 
-            if (Preferences.browserNotificationsEnabled.value) {
+            if (Preferences.isEnabled.value && Preferences.browserNotificationsEnabled.value) {
                 // Example: show a notification about the found pages
                 // NOTE: Requires "notifications" permission in your manifest.json
                 void browser.notifications.create({
@@ -58,7 +58,13 @@ export class Main {
                     message: `Found ${pages.totalPagesFound.toString()} page(s).`,
                 });
             }
-            if (Preferences.pageNotificationsEnabled.value) {
+            if (Preferences.isEnabled.value && Preferences.pageNotificationsEnabled.value) {
+                console.log({
+                    preferences: {
+                        isEnabled: Preferences.isEnabled.value,
+                        pageNotificationsEnabled: Preferences.pageNotificationsEnabled.value,
+                    },
+                });
                 const message = `Found ${pages.totalPagesFound.toString()} CAT page(s).`;
                 domMessenger
                     .showInPageNotification(message)


### PR DESCRIPTION
Thank you for your contribution to the ClintonCAT repo.
Before submitting this PR, please make sure:

----
- [x] The target of this PR is the `main` branch.
- [x] No commits are missing from forked base branch (e.g. modified main branch instead of dev)
- [x] You have squashed commits that might be considered: 'noisy' or partial, e.g. not candidates for cherry picking
- [x] All test pass, run `npm test`
- [x] The code is formatted, run `npm run format`
- [x] You have updated or added test cases, as/if required
- [x] You have installed and tried out the plugin in a supported browser

---
Addresses #86 

Noticed that notifications wasn't checking if the extension was enabled or not. This PR adds a check to both notifications to see if the extension has been disabled.

[Screencast from 2025-05-29 23-00-54.webm](https://github.com/user-attachments/assets/0e41be71-5804-43d5-ac2c-ddc63c58499f)

I think there's still some buginess with how "responsive" the extension is to being turned on/off. Seems to need a refresh to catch on that the settings were changed.