### PR TITLE
Fix setting updates not observed immediately by notifications

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -48,37 +48,41 @@ export class Main {
             // Update badge text with total pages found
             void browser.action.setBadgeText({ text: pages.totalPagesFound.toString() });
 
-            if (Preferences.isEnabled.value && Preferences.browserNotificationsEnabled.value) {
-                // Example: show a notification about the found pages
-                // NOTE: Requires "notifications" permission in your manifest.json
-                void browser.notifications.create({
-                    type: 'basic',
-                    iconUrl: browser.runtime.getURL('alert.png'),
-                    title: 'CAT Pages Found',
-                    message: `Found ${pages.totalPagesFound.toString()} page(s).`,
-                });
-            }
-            if (Preferences.isEnabled.value && Preferences.pageNotificationsEnabled.value) {
-                console.log({
-                    preferences: {
-                        isEnabled: Preferences.isEnabled.value,
-                        pageNotificationsEnabled: Preferences.pageNotificationsEnabled.value,
-                    },
-                });
-                const message = `Found ${pages.totalPagesFound.toString()} CAT page(s).`;
-                domMessenger
-                    .showInPageNotification(message)
-                    .then(() => console.log('In-page notification shown.'))
-                    .catch((error: unknown) => {
-                        if (error instanceof Error && error.message.includes('Receiving end does not exist')) {
-                            console.warn(
-                                `Failed to send in-page notification (tab might be inactive or closed/navigated away before message was sent): ${error.message}`
-                            );
-                        } else {
-                            console.error('Failed to show in-page notification due to unexpected error:', error);
-                        }
+            Promise.all([
+                Preferences.getPreference(Preferences.IS_ENABLED_KEY),
+                Preferences.getPreference(Preferences.BROWSER_NOTIFICATIONS_ENABLED_KEY),
+            ]).then(([isEnabled, browserNotificationsEnabled]) => {
+                if (isEnabled && browserNotificationsEnabled) {
+                    // Example: show a notification about the found pages
+                    // NOTE: Requires "notifications" permission in your manifest.json
+                    void browser.notifications.create({
+                        type: 'basic',
+                        iconUrl: browser.runtime.getURL('alert.png'),
+                        title: 'CAT Pages Found',
+                        message: `Found ${pages.totalPagesFound.toString()} page(s).`,
                     });
-            }
+                }
+            });
+            Promise.all([
+                Preferences.getPreference(Preferences.IS_ENABLED_KEY),
+                Preferences.getPreference(Preferences.PAGE_NOTIFICATIONS_ENABLED_KEY),
+            ]).then(([isEnabled, pageNotificationsEnabled]) => {
+                if (isEnabled && pageNotificationsEnabled) {
+                    const message = `Found ${pages.totalPagesFound.toString()} CAT page(s).`;
+                    domMessenger
+                        .showInPageNotification(message)
+                        .then(() => console.log('In-page notification shown.'))
+                        .catch((error: unknown) => {
+                            if (error instanceof Error && error.message.includes('Receiving end does not exist')) {
+                                console.warn(
+                                    `Failed to send in-page notification (tab might be inactive or closed/navigated away before message was sent): ${error.message}`
+                                );
+                            } else {
+                                console.error('Failed to show in-page notification due to unexpected error:', error);
+                            }
+                        });
+                }
+            });
         } else {
             // Revert badge text back to "on" or "off" as set by indicateStatus
             this.indicateStatus();
@@ -86,19 +90,21 @@ export class Main {
     }
 
     notify(message: string) {
-        if (Preferences.browserNotificationsEnabled.value) {
-            const notificationId = 'abc123';
-            const options: browser.Notifications.CreateNotificationOptions = {
-                type: 'basic',
-                iconUrl: browser.runtime.getURL('alert.png'),
-                title: 'Hey',
-                message,
-            };
+        Preferences.getPreference(Preferences.BROWSER_NOTIFICATIONS_ENABLED_KEY).then((browserNotificationsEnabled) => {
+            if (browserNotificationsEnabled) {
+                const notificationId = 'abc123';
+                const options: browser.Notifications.CreateNotificationOptions = {
+                    type: 'basic',
+                    iconUrl: browser.runtime.getURL('alert.png'),
+                    title: 'Hey',
+                    message,
+                };
 
-            void browser.notifications.create(notificationId, options);
-        } else {
-            console.log('Browser notifications are disabled. Skipping notification.');
-        }
+                void browser.notifications.create(notificationId, options);
+            } else {
+                console.log('Browser notifications are disabled. Skipping notification.');
+            }
+        });
     }
 
     /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,38 +51,49 @@ export class Main {
             Promise.all([
                 Preferences.getPreference(Preferences.IS_ENABLED_KEY),
                 Preferences.getPreference(Preferences.BROWSER_NOTIFICATIONS_ENABLED_KEY),
-            ]).then(([isEnabled, browserNotificationsEnabled]) => {
-                if (isEnabled && browserNotificationsEnabled) {
-                    // Example: show a notification about the found pages
-                    // NOTE: Requires "notifications" permission in your manifest.json
-                    void browser.notifications.create({
-                        type: 'basic',
-                        iconUrl: browser.runtime.getURL('alert.png'),
-                        title: 'CAT Pages Found',
-                        message: `Found ${pages.totalPagesFound.toString()} page(s).`,
-                    });
-                }
-            });
+            ])
+                .then(([isEnabled, browserNotificationsEnabled]) => {
+                    if (isEnabled && browserNotificationsEnabled) {
+                        // Example: show a notification about the found pages
+                        // NOTE: Requires "notifications" permission in your manifest.json
+                        void browser.notifications.create({
+                            type: 'basic',
+                            iconUrl: browser.runtime.getURL('alert.png'),
+                            title: 'CAT Pages Found',
+                            message: `Found ${pages.totalPagesFound.toString()} page(s).`,
+                        });
+                    }
+                })
+                .catch((error: unknown) =>
+                    console.error('Failed to get preferences to send browser notification:', error)
+                );
             Promise.all([
                 Preferences.getPreference(Preferences.IS_ENABLED_KEY),
                 Preferences.getPreference(Preferences.PAGE_NOTIFICATIONS_ENABLED_KEY),
-            ]).then(([isEnabled, pageNotificationsEnabled]) => {
-                if (isEnabled && pageNotificationsEnabled) {
-                    const message = `Found ${pages.totalPagesFound.toString()} CAT page(s).`;
-                    domMessenger
-                        .showInPageNotification(message)
-                        .then(() => console.log('In-page notification shown.'))
-                        .catch((error: unknown) => {
-                            if (error instanceof Error && error.message.includes('Receiving end does not exist')) {
-                                console.warn(
-                                    `Failed to send in-page notification (tab might be inactive or closed/navigated away before message was sent): ${error.message}`
-                                );
-                            } else {
-                                console.error('Failed to show in-page notification due to unexpected error:', error);
-                            }
-                        });
-                }
-            });
+            ])
+                .then(([isEnabled, pageNotificationsEnabled]) => {
+                    if (isEnabled && pageNotificationsEnabled) {
+                        const message = `Found ${pages.totalPagesFound.toString()} CAT page(s).`;
+                        domMessenger
+                            .showInPageNotification(message)
+                            .then(() => console.log('In-page notification shown.'))
+                            .catch((error: unknown) => {
+                                if (error instanceof Error && error.message.includes('Receiving end does not exist')) {
+                                    console.warn(
+                                        `Failed to send in-page notification (tab might be inactive or closed/navigated away before message was sent): ${error.message}`
+                                    );
+                                } else {
+                                    console.error(
+                                        'Failed to show in-page notification due to unexpected error:',
+                                        error
+                                    );
+                                }
+                            });
+                    }
+                })
+                .catch((error: unknown) =>
+                    console.error('Failed to get preferences to send in-page notification:', error)
+                );
         } else {
             // Revert badge text back to "on" or "off" as set by indicateStatus
             this.indicateStatus();
@@ -90,21 +101,23 @@ export class Main {
     }
 
     notify(message: string) {
-        Preferences.getPreference(Preferences.BROWSER_NOTIFICATIONS_ENABLED_KEY).then((browserNotificationsEnabled) => {
-            if (browserNotificationsEnabled) {
-                const notificationId = 'abc123';
-                const options: browser.Notifications.CreateNotificationOptions = {
-                    type: 'basic',
-                    iconUrl: browser.runtime.getURL('alert.png'),
-                    title: 'Hey',
-                    message,
-                };
+        Preferences.getPreference(Preferences.BROWSER_NOTIFICATIONS_ENABLED_KEY)
+            .then((browserNotificationsEnabled) => {
+                if (browserNotificationsEnabled) {
+                    const notificationId = 'abc123';
+                    const options: browser.Notifications.CreateNotificationOptions = {
+                        type: 'basic',
+                        iconUrl: browser.runtime.getURL('alert.png'),
+                        title: 'Hey',
+                        message,
+                    };
 
-                void browser.notifications.create(notificationId, options);
-            } else {
-                console.log('Browser notifications are disabled. Skipping notification.');
-            }
-        });
+                    void browser.notifications.create(notificationId, options);
+                } else {
+                    console.log('Browser notifications are disabled. Skipping notification.');
+                }
+            })
+            .catch((error: unknown) => console.error('Failed to get preferences to send browser notification:', error));
     }
 
     /**


### PR DESCRIPTION
Thank you for your contribution to the ClintonCAT repo.
Before submitting this PR, please make sure:

----
- [x] The target of this PR is the `main` branch.
- [x] No commits are missing from forked base branch (e.g. modified main branch instead of dev)
- [x] You have squashed commits that might be considered: 'noisy' or partial, e.g. not candidates for cherry picking
- [x] All test pass, run `npm test`
- [x] The code is formatted, run `npm run format`
- [x] You have updated or added test cases, as/if required
- [x] You have installed and tried out the plugin in a supported browser
---

Goal of this PR is to make the notifications respect the settings better. Previously it'd lag and not register that the settings have changed until at least 1 refresh.

Looking for feedback on my approach and if there would be other places that could use this instead of trying to read the value straight from the Observable. 

This PR doesn't include making the extension icon text more responsive. That I'm aiming for in a different PR.

[Screencast from 2025-05-30 20-42-59.webm](https://github.com/user-attachments/assets/7e21d04e-7171-4da4-ab95-f500c07e4341)
