### PR TITLE
Fix setBadgeText function to show number of articles per tab

### DIFF
--- a/src/common/helpers/dom-messenger.ts
+++ b/src/common/helpers/dom-messenger.ts
@@ -69,6 +69,15 @@ class DOMMessenger implements IDOMMessengerInterface {
         });
     }
 
+    public async setBadgeText(text: string): Promise<unknown> {
+        console.log('Setting badge text: ', text);
+        const tab = await this.getCurrentTab();
+        return await browser.action.setBadgeText({
+            text: text,
+            tabId: tab.id,
+        });
+    }
+
     // TODO: createElementWithChildSelector ?
     // public async createElementWithChildSelector(
     //     parentId: string,
@@ -111,7 +120,6 @@ class DOMMessenger implements IDOMMessengerInterface {
         if (!tab.id) {
             throw new Error('No active tab found');
         }
-
         return await browser.tabs.sendMessage(tab.id, message);
     }
 

--- a/src/common/helpers/dom-messenger.types.ts
+++ b/src/common/helpers/dom-messenger.types.ts
@@ -7,6 +7,7 @@ export interface IDOMMessengerInterface {
     querySelectorAllAsText(selector: string): Promise<string>;
     createElement(parentId: string, element: string, html: string): Promise<void>;
     showInPageNotification(message: string): Promise<unknown>;
+    setBadgeText(text: string): Promise<unknown>;
 }
 
 export enum DOMMessengerAction {

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,8 +45,7 @@ export class Main {
         console.log(pages);
 
         if (totalPages > 0) {
-            // Update badge text with total pages found
-            void browser.action.setBadgeText({ text: pages.totalPagesFound.toString() });
+            this.onBadgeTextUpdate(totalPages.toString(), domMessenger);
 
             Promise.all([
                 Preferences.getPreference(Preferences.IS_ENABLED_KEY),
@@ -96,6 +95,7 @@ export class Main {
                 );
         } else {
             // Revert badge text back to "on" or "off" as set by indicateStatus
+            console.log('Resetting badge text');
             this.indicateStatus();
         }
     }
@@ -123,8 +123,14 @@ export class Main {
     /**
      * Called when the extension wants to change the action badge text manually.
      */
-    onBadgeTextUpdate(text: string): void {
-        void browser.action.setBadgeText({ text: text });
+    onBadgeTextUpdate(text: string, domMessenger: IDOMMessengerInterface): void {
+        // Update badge text with total pages found
+        domMessenger
+            .setBadgeText(text)
+            .then(() => console.log('Badge text set...'))
+            .catch((error: unknown) => {
+                console.error('Failed to set badge text due to an unexpected error:', error);
+            });
     }
 
     checkDomainIsExcluded(domain: string): boolean {


### PR DESCRIPTION
This PR fixes a race condition where the extension set the badge text to the number of CAT pages detected on a product/company site, however the badge text quickly switched back to the "on" when the browser finished loading the webpage.

I tested this in the Firefox browser, and sets the number of CAT articles found on the extension badge per tab. 

Before, 

When installing the extension, the product/company page has to get reloaded for the badge text to be set correctly.

The commands `npm test` and `npm run format` has been run on my code and everything passed.

For example (on Microsoft, Apple, and on the Firefox add-on page), the user sees the following:

### Firefox
**Apple:**
<img width="377" height="97" alt="image" src="https://github.com/user-attachments/assets/b97145d3-930a-47a6-91f2-c61501d77235" />

**Microsoft:**
<img width="385" height="110" alt="image" src="https://github.com/user-attachments/assets/e5231035-2dff-4f9d-919a-2643a477c92f" />

**Debugging (native Firefox page):**
<img width="376" height="100" alt="image" src="https://github.com/user-attachments/assets/370ebfe5-d93a-4fa1-846a-32621967c52a" />

### Chromium
**Apple**
<img width="401" height="103" alt="image" src="https://github.com/user-attachments/assets/d58304be-57ce-41ac-8b39-d4d5e782a3b1" />
**Microsoft**
<img width="402" height="107" alt="image" src="https://github.com/user-attachments/assets/4559499f-20ab-42a6-9c78-0ef3262424e8" />
**Extension page (native Chromium page)**
<img width="400" height="106" alt="image" src="https://github.com/user-attachments/assets/c4248f13-d27a-4c79-8ea7-801965c9721e" />

----
Thank you for your contribution to the ClintonCAT repo.
Before submitting this PR, please make sure:

----
- [x] The target of this PR is the `main` branch.
- [x] No commits are missing from forked base branch (e.g. modified main branch instead of dev)
- [x] You have squashed commits that might be considered: 'noisy' or partial, e.g. not candidates for cherry picking
- [x] All test pass, run `npm test`
- [x] The code is formatted, run `npm run format`
- [x] You have updated or added test cases, as/if required
- [x] You have installed and tried out the plugin in a supported browser
