### PR TITLE
Improved in browser message

### DIFF
--- a/src/common/helpers/dom-messenger.test.ts
+++ b/src/common/helpers/dom-messenger.test.ts
@@ -225,15 +225,20 @@ describe('DOMMessenger', () => {
                 sendResponse
             );
 
-            const container = document.getElementById('clint-cat-notification-container');
+            const id = DOMMessenger.makeId();
+
+            const container = document.getElementById(id);
             expect(container).not.toBeNull();
-            expect(container?.style.position).toBe('fixed');
-            expect(container?.children.length).toBeGreaterThan(0);
-            const notificationElement = container?.children[0] as HTMLElement;
+
+            const shadow = container?.shadowRoot;
+
+            const shadowElement = shadow?.children[1] as HTMLElement;
+            expect(shadowElement?.style.position).toBe('fixed');
+            expect(shadowElement?.children.length).toBeGreaterThan(0);
+
+            const notificationElement = shadowElement?.children[0] as HTMLElement;
             expect(notificationElement).not.toBeNull();
             expect(notificationElement.textContent).toContain(testMessage);
-            expect(notificationElement.childNodes[0].nodeValue).toBe(testMessage);
-            expect(notificationElement.querySelector('button')).not.toBeNull();
             expect(sendResponse).toHaveBeenCalledWith({ success: true });
         });
 

--- a/src/common/helpers/dom-messenger.ts
+++ b/src/common/helpers/dom-messenger.ts
@@ -236,67 +236,187 @@ class DOMMessenger implements IDOMMessengerInterface {
             return true;
         });
     }
-    private static displayNotification(message: string): void {
-        const containerId = 'clint-cat-notification-container';
-        let container = document.getElementById(containerId);
 
-        if (!container) {
-            container = document.createElement('div');
-            container.id = containerId;
-            Object.assign(container.style, {
-                position: 'fixed',
-                top: '10px',
-                right: '10px',
-                zIndex: '2147483647',
-                display: 'flex',
-                flexDirection: 'column',
-                gap: '10px',
-                maxWidth: '300px',
-            });
-            document.body.appendChild(container);
+    /*
+        makeId unique maybe this should be eutils helper ?
+        Original code from https://stackoverflow.com/questions/1349404/generate-a-string-of-random-characters
+    */
+    static elementId: string = '';
+    private static makeId(): string {
+        if (DOMMessenger.elementId == '') {
+            const length = 20;
+            let result = '';
+            const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+            const charactersLength = characters.length;
+            for (let i = 0; i < length; i++) {
+                result += characters.charAt(Math.floor(Math.random() * charactersLength));
+            }
+            DOMMessenger.elementId = result;
         }
-        const notificationElement = document.createElement('div');
-        notificationElement.appendChild(document.createTextNode(message));
+        return DOMMessenger.elementId;
+    }
 
-        const baseStyle: Partial<CSSStyleDeclaration> = {
-            padding: '15px',
-            borderRadius: '5px',
-            color: '#fff',
-            backgroundColor: '#4CAF50',
-            boxShadow: '0 2px 5px rgba(0,0,0,0.2)',
-            opacity: '1',
-            transition: 'opacity 0.5s ease-out',
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
+    static timeoutID: NodeJS.Timeout;
+    private static displayNotification(message: string): void {
+        /*
+            if we are to use timeout we should clear,
+            if not it creats a buggy behavior if more than one message is "displayed."
+        */
+        if (DOMMessenger.timeoutID) {
+            clearTimeout(DOMMessenger.timeoutID);
+        }
+
+        /*
+            All styling in this, function is up for change, improvement.
+            the use of shadowDOM is in my opinion a must.
+        */
+        const containerId = DOMMessenger.makeId();
+        const hostcontainer = document.getElementById(containerId);
+
+        // remove the exsisting container, so a new can be created.
+        if (hostcontainer) {
+            hostcontainer.remove();
+        }
+        const host = document.createElement('div');
+        host.id = containerId;
+
+        const shadow = host.attachShadow({ mode: 'open' }); // should we use closed to protect the content ?
+
+        // styling added here is to prevent css from "parent" to leak in to the shadowDOM
+        // here the contailer styling can also be added if need be.
+        shadow.innerHTML = `
+            <style>
+                :host {
+                    all: initial;
+                    display: block;
+
+                    /* Block inherited root styles */
+                    font-family: system-ui, sans-serif;
+                    color: black;
+                    --main-color: initial;
+                    --some-other-var: initial;
+                }
+
+                *, *::before, *::after {
+                    all: unset;
+                    display: revert;
+                    box-sizing: border-box;
+                }
+
+                /* Optionally restore HTML5 block elements */
+                    div, p, h1, h2, h3, h4, h5, h6, section, article, header, footer {
+                    display: block;
+                }
+                div {
+                    all: initial;
+                }
+                body, div {
+                    font-family: system-ui, sans-serif;
+                    font-size: 14px;
+                    color: black;
+                    background: white;
+                }        
+            </style>
+`;
+
+        const container = document.createElement('div');
+        shadow.appendChild(container);
+
+        /*
+            clear time out if mouse moves over the message assume user whants to interact with it.
+        */
+        container.onmouseover = () => {
+            if (DOMMessenger.timeoutID) {
+                clearTimeout(DOMMessenger.timeoutID);
+            }
         };
 
-        Object.assign(notificationElement.style, baseStyle);
-
-        const closeButton = document.createElement('button');
-        closeButton.textContent = '×';
-        Object.assign(closeButton.style, {
-            marginLeft: '15px',
-            background: 'none',
-            border: 'none',
-            color: 'inherit',
-            fontSize: '20px',
-            cursor: 'pointer',
-            padding: '0',
-            lineHeight: '1',
+        Object.assign(container.style, {
+            background: '#fff',
+            boxShadow: '0 4px 40px 3px rgb(0 0 0 / 100%)',
+            padding: '10px',
+            margin: '20px',
+            width: '400px',
+            height: 'auto',
+            position: 'fixed',
+            right: '0px',
+            top: '0px',
+            zIndex: '2147483647',
+            display: 'inline-block',
+            borderColor: 'red',
+            borderStyle: 'solid',
+            borderWidth: '2px',
+            borderRadius: '0 0 1rem 1rem',
+            marginTop: '0',
+            borderTop: 'none',
         });
-        closeButton.onclick = () => {
-            notificationElement.style.opacity = '0';
-            setTimeout(() => notificationElement.remove(), 500);
-        };
-        notificationElement.appendChild(closeButton);
 
+        const notificationElement = document.createElement('div');
+
+        const closeElement = document.createElement('span');
+        closeElement.appendChild(document.createTextNode('✖'));
+        Object.assign(closeElement.style, {
+            float: 'right',
+            cursor: 'pointer',
+            fontWeight: 'bold',
+            marginLeft: '10px',
+        });
+        closeElement.onclick = () => {
+            if (DOMMessenger.timeoutID) {
+                clearTimeout(DOMMessenger.timeoutID);
+            }
+            host.remove();
+            /* TODO:
+                feature so that we can "mute" further popups so they dont keep comming up every time up.
+                if/when each individual page is listed in the message, each page should have its own "dismiss", button.
+                    this should be the case so that only if new pages are displayed (maybe if modifyed too?),
+                    not sure if cargo file will has this info
+            */
+        };
+
+        const linkElement = document.createElement('a');
+        linkElement.href = 'https://consumerrights.wiki/'; // should be a variable
+        linkElement.target = '_blank';
+
+        Object.assign(linkElement.style, {
+            display: 'flex',
+            height: '100%',
+            alignItems: 'center',
+            minWidth: '13.875em',
+            color: '#4b77d6',
+            textDecoration: 'none',
+        });
+
+        const imgElement = document.createElement('img');
+        imgElement.src = 'https://consumerrights.wiki/images/logo/new_fixed_logo.png'; // should be a variable
+        Object.assign(imgElement.style, {
+            width: '50px',
+            height: '50px',
+            display: 'inline-block',
+        });
+
+        const textSpanElement = document.createElement('span');
+        const textStrongElement = document.createElement('strong');
+
+        textStrongElement.appendChild(document.createTextNode('Consumer Rights Wiki'));
+
+        textSpanElement.appendChild(textStrongElement);
+
+        linkElement.appendChild(imgElement);
+        linkElement.appendChild(textSpanElement);
+
+        notificationElement.appendChild(closeElement);
+        notificationElement.appendChild(linkElement);
+        notificationElement.appendChild(document.createTextNode(message));
         container.prepend(notificationElement);
 
-        setTimeout(() => {
-            if (notificationElement.parentElement) {
-                notificationElement.style.opacity = '0';
-                setTimeout(() => notificationElement.remove(), 500);
+        document.body.appendChild(host);
+
+        // i am not sure we really want this, if we do it should be a option from the user. (maybe time ajustable ?)
+        DOMMessenger.timeoutID = setTimeout(() => {
+            const hostcontainer = document.getElementById(containerId);
+            if (hostcontainer) {
+                hostcontainer.remove();
             }
         }, 5000);
     }

--- a/src/common/helpers/dom-messenger.ts
+++ b/src/common/helpers/dom-messenger.ts
@@ -242,7 +242,7 @@ class DOMMessenger implements IDOMMessengerInterface {
         Original code from https://stackoverflow.com/questions/1349404/generate-a-string-of-random-characters
     */
     static elementId: string = '';
-    private static makeId(): string {
+    public static makeId(): string {
         if (DOMMessenger.elementId == '') {
             const length = 20;
             let result = '';


### PR DESCRIPTION
headlines

- autohide notice cleared if mouse over message
- use of shadomDOM to prevent css interaction between page and the "popup"
- ID of the element is no longer "clint-cat-notification-container", but a random string as i fear it would be to easy for melisious code on the pages to find and remove (tho at this point in time it is not needed)
- In message added link/logo to the wiki and this should properly be done via variables instead of "hard coded".

<img width="528" height="147" alt="billede" src="https://github.com/user-attachments/assets/3bd16ec2-4a9a-43e7-b32c-165803e55894" />

NOTE:
I currently only tested with firefox i am not sure if it should be tested in "all" supported browsers?

Also like to point out the styling is of cause not my strong side, and up for debate/ input and what not.

also i am not 100 % sure the test case is good enough.

----
- [x] The target of this PR is the `main` branch.
- [x] No commits are missing from forked base branch (e.g. modified main branch instead of dev)
- [x] You have squashed commits that might be considered: 'noisy' or partial, e.g. not candidates for cherry picking
- [x] All test pass, run `npm test`
- [x] The code is formatted, run `npm run format`
- [x] You have updated or added test cases, as/if required
- [x] You have installed and tried out the plugin in a supported browser
