### PR TITLE
Generic plugin that  can be configured to cover manny different searc…

### DIFF
--- a/src/content-scanners/generic-search-engine/generic-search-engine.ts
+++ b/src/content-scanners/generic-search-engine/generic-search-engine.ts
@@ -1,0 +1,108 @@
+import { IScanParameters } from '@/common/services/content-scanner.types';
+import { BaseDomainScanner } from '../base-domain-scanner';
+import { getDomainWithoutSuffix } from 'tldts';
+
+export interface ISearchEngine {
+    domain: string;
+    search: string;
+    path: string | null;
+}
+
+/**
+ * configure dimain to search parameter
+ */
+const SearchEngines: ISearchEngine[] = [
+    {
+        domain: 'bing',
+        search: 'q',
+        path: null,
+    },
+    {
+        domain: 'yahoo',
+        search: 'p',
+        path: null,
+    },
+    {
+        domain: 'brave' /* domain is actuarly search.brave.com, but it still works. */,
+        search: 'q',
+        path: null,
+    },
+    {
+        domain: 'duckduckgo',
+        search: 'q',
+        path: null,
+    },
+    {
+        domain: 'archive',
+        search: 'query',
+        path: null,
+    },
+    {
+        domain: 'facebook',
+        search: 'q' /* when search is preformed it dont reload the whole page so we dont update, we need a "hook" that detect url change code can run there aswell*/,
+        path: null,
+    },
+    {
+        domain: 'x',
+        search: 'q' /* when search is preformed it dont reload the whole page so we dont update, we need a "hook" that detect url change code can run there aswell*/,
+        path: null,
+    },
+    {
+        domain: 'wikipedia',
+        search: 'search',
+        path: '^/wiki/([^/?]+)',
+    },
+];
+
+/**
+ * Generic plugin that can cover manny search engines with little effort
+ */
+class GenericSearchEngineScanner extends BaseDomainScanner {
+    metaInfo(): string {
+        return 'generic-search-engine';
+    }
+
+    canScanContent(params: IScanParameters): boolean {
+        for (const engine of SearchEngines) {
+            if (params.mainDomain === engine.domain) {
+                return params.mainDomain == engine.domain;
+            }
+        }
+        return false;
+    }
+
+    protected getDomainKeyForSearch(params: IScanParameters): string {
+        for (const engine of SearchEngines) {
+            if (params.mainDomain === engine.domain) {
+                return params.mainDomain;
+            }
+        }
+        return '';
+    }
+
+    protected override extractEntity(url: string): string | null {
+        const scannerName = this.constructor.name;
+        try {
+            const urlObject = new URL(url);
+            const domain = getDomainWithoutSuffix(urlObject.host, { allowPrivateDomains: true }) ?? '';
+            for (const engine of SearchEngines) {
+                if (domain === engine.domain) {
+                    if (engine.path) {
+                        const match = urlObject.pathname.match(engine.path);
+                        if (match) {
+                            return match[1].toLowerCase();
+                        }
+                    }
+                    return urlObject.searchParams.get(engine.search);
+                }
+            }
+        } catch (error) {
+            console.error(`${scannerName}: Error parsing URL:`, error);
+        }
+
+        console.log(`${scannerName}: Could not extract from URL: ${url}`);
+        return null;
+    }
+}
+
+export default GenericSearchEngineScanner;


### PR DESCRIPTION
A generic plugin that can be configured to be many pages at the same time.

done by configuring a ISearchEngine 
doman = domain name
search = what argument in the url that has the search content.
path= regex where match #1 has to be the search tearm wg for wikipedia /wiki/(pagename) this only happens if you search for something and it gives a singel page instead of ?q=somepage

----
- [x] The target of this PR is the `main` branch.
- [x] No commits are missing from forked base branch (e.g. modified main branch instead of dev)
- [x] You have squashed commits that might be considered: 'noisy' or partial, e.g. not candidates for cherry picking
- [x] All test pass, run `npm test`
- [x] The code is formatted, run `npm run format`
- [x] You have updated or added test cases, as/if required
- [x] You have installed and tried out the plugin in a supported browser
