### PR TITLE
Re-enable updating PagesDB with exported file in GitHub

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -41,7 +41,7 @@ export class CATWikiPageSearchResults {
 
 export class PagesDB {
     static readonly PAGES_DB_JSON_URL: string =
-        'https://raw.githubusercontent.com/WayneKeenan/ClintonCAT/refs/heads/main/data/pages_db.json';
+        'https://raw.githubusercontent.com/WKDLabs/CATWikiCargoPrototype/refs/heads/export/data/all_cargo_combined.json';
     private companyPages: CompanyPage[] = [];
     private incidentPages: IncidentPage[] = [];
     private productPages: ProductPage[] = [];

--- a/src/storage/storage-cache.ts
+++ b/src/storage/storage-cache.ts
@@ -18,10 +18,10 @@ class StorageCache {
         });
         browser.alarms.onAlarm.addListener((alarm) => {
             if (alarm.name === StorageCache.UPDATE_ALARM_NAME) {
-                // void this.updatePagesDB();
+                void this.updatePagesDB();
             }
         });
-        // void this.updatePagesDB();
+        void this.updatePagesDB();
     }
 
     setDatabaseTarget(pagesDb: PagesDB): void {


### PR DESCRIPTION
Thank you for your contribution to the ClintonCAT repo.
Before submitting this PR, please make sure:

----
- [x] The target of this PR is the `main` branch.
- [x] No commits are missing from forked base branch (e.g. modified main branch instead of dev)
- [x] You have squashed commits that might be considered: 'noisy' or partial, e.g. not candidates for cherry picking
- [x] All test pass, run `npm test`
- [x] The code is formatted, run `npm run format`
- [x] You have updated or added test cases, as/if required
- [x] You have installed and tried out the plugin in a supported browser

The goal of the PR is to re-enable fetching the remote pages DB file that's exported to GitHub. This will give developers more up-to-date data to work with.

Successful request to fetch exported JSON (inspecting network for extension):
<img width="1757" height="1014" alt="Screenshot from 2025-08-19 22-46-58" src="https://github.com/user-attachments/assets/f4d1635d-ce7d-4540-a471-fba885f46d73" />
