### PR TITLE
Added: in page notification options

### DIFF
--- a/public/_locales/da/messages.json
+++ b/public/_locales/da/messages.json
@@ -69,5 +69,39 @@
     },
     "GO_TO_OPTIONS": {
         "message": "Gå til indstillinger"
+    },
+    "SHOW_MORE_OPTION": {
+        "message": "Vis mere option"
+    },
+    "SHOW_MUTE_OPTION": {
+        "message": "Vis skjul option"
+    },
+    "SHOW_HIDE_OPTION": {
+        "message": "Vis fjern option"
+    },
+    "AUTOHIDE_LABEL": {
+        "message": "Skjul automatisk, $seconds$ sekunder",
+        "placeholders": {
+            "seconds": {
+                "content": "$1"
+            }
+        }
+    },
+    "DISMISS_TIME_LABEL": {
+        "message": "Skjul tid, $houers$ timer",
+        "placeholders": {
+            "houers": {
+                "content": "$1"
+            }
+        }
+    },
+    "OFF": {
+        "message": "Slukket"
+    },
+    "30": {
+        "message": "30"
+    },
+    "IN_PAGE_SETTINGS": {
+        "message": "Side besked instillinger"
     }
 }

--- a/public/_locales/da/messages.json
+++ b/public/_locales/da/messages.json
@@ -88,9 +88,9 @@
         }
     },
     "DISMISS_TIME_LABEL": {
-        "message": "Skjul tid, $houers$ timer",
+        "message": "Skjul tid, $hours$ timer",
         "placeholders": {
-            "houers": {
+            "hours": {
                 "content": "$1"
             }
         }

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -11,6 +11,14 @@
     "EXCLUDED_DOMAINS": {
         "message": "Excluded Domains"
     },
+    "DOMAIN_NOT_VALID": {
+        "message": "$domainInput$ is not a valid domain",
+        "placeholders": {
+            "domainInput": {
+                "content": "$1"
+            }
+        }
+    },
     "ADD": {
         "message": "ADD"
     },
@@ -61,5 +69,39 @@
     },
     "GO_TO_OPTIONS": {
         "message": "Go to Options"
+    },
+    "SHOW_MORE_OPTION": {
+        "message": "Show more option"
+    },
+    "SHOW_MUTE_OPTION": {
+        "message": "Show mute option"
+    },
+    "SHOW_HIDE_OPTION": {
+        "message": "Show hide option"
+    },
+    "AUTOHIDE_LABEL": {
+        "message": "Autohide message, $seconds$ seconds",
+        "placeholders": {
+            "seconds": {
+                "content": "$1"
+            }
+        }
+    },
+    "DISMISS_TIME_LABEL": {
+        "message": "Dismiss time, $houers$ houers",
+        "placeholders": {
+            "houers": {
+                "content": "$1"
+            }
+        }
+    },
+    "OFF": {
+        "message": "OFF"
+    },
+    "30": {
+        "message": "30"
+    },
+    "IN_PAGE_SETTINGS": {
+        "message": "In page message settings"
     }
 }

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -88,9 +88,9 @@
         }
     },
     "DISMISS_TIME_LABEL": {
-        "message": "Dismiss time, $houers$ houers",
+        "message": "Dismiss time, $hours$ hours",
         "placeholders": {
-            "houers": {
+            "hours": {
                 "content": "$1"
             }
         }

--- a/src/common/helpers/dom-messenger.test.ts
+++ b/src/common/helpers/dom-messenger.test.ts
@@ -7,6 +7,7 @@ import DOMMessenger from './dom-messenger';
 import { DOMMessengerAction, IShowInPageNotificationPayload } from './dom-messenger.types';
 import { IPage } from '@/models/page';
 import { CompanyPage } from '@/models/company';
+import { IInPageNotificationOptions } from '@/ui/inpagenotification/Inspagenotification';
 
 type MessagePayload =
     | { action: DOMMessengerAction.DOM_QUERY_SELECTOR_ALL; selector: string }
@@ -17,6 +18,7 @@ type MessagePayload =
     | ({
           action: DOMMessengerAction.DOM_SHOW_IN_PAGE_NOTIFICATION;
           pages: IPage[];
+          options: IInPageNotificationOptions;
       } & IShowInPageNotificationPayload);
 
 type MessageListener = (
@@ -237,8 +239,20 @@ describe('DOMMessenger', () => {
 
             const pages = [testPage];
 
+            const options: IInPageNotificationOptions = {
+                showMore: true,
+                showMute: true,
+                showHide: true,
+                autoHideTime: 5000,
+            };
+
             listener(
-                { action: DOMMessengerAction.DOM_SHOW_IN_PAGE_NOTIFICATION, message: testMessage, pages: pages },
+                {
+                    action: DOMMessengerAction.DOM_SHOW_IN_PAGE_NOTIFICATION,
+                    message: testMessage,
+                    pages: pages,
+                    options: options,
+                },
                 {},
                 sendResponse
             );

--- a/src/common/helpers/dom-messenger.types.ts
+++ b/src/common/helpers/dom-messenger.types.ts
@@ -1,4 +1,5 @@
 import { IElementData } from '@/common/services/content-scanner.types';
+import { IInPageNotificationOptions } from '@/ui/inpagenotification/Inspagenotification';
 
 export interface IDOMMessengerInterface {
     querySelectorAll(selector: string): Promise<IElementData[]>;
@@ -6,7 +7,7 @@ export interface IDOMMessengerInterface {
     querySelectorByParentId(id: string, selector: string): Promise<IElementData | undefined | null>;
     querySelectorAllAsText(selector: string): Promise<string>;
     createElement(parentId: string, element: string, html: string): Promise<void>;
-    showInPageNotification(message: string, entries: object[]): Promise<unknown>;
+    showInPageNotification(message: string, entries: object[], options: IInPageNotificationOptions): Promise<unknown>;
     setBadgeText(text: string): Promise<unknown>;
 }
 

--- a/src/common/services/preferences.ts
+++ b/src/common/services/preferences.ts
@@ -10,10 +10,23 @@ class Preferences {
     static readonly PAGE_NOTIFICATIONS_ENABLED_KEY = 'page_notifications_enabled';
     static readonly DEFAULT_DOMAIN_EXCLUSIONS = ['rossmanngroup.com'];
 
+    static readonly PAGE_NOTIFICATIONS_AUTOHIDETIME_KEY = 'page_notifications_autohide';
+    static readonly PAGE_NOTIFICATIONS_DISMISSTIME_KEY = 'page_notifications_dismiss_time';
+    static readonly PAGE_NOTIFICATIONS_SHOWMORE_KEY = 'page_notifications_show_more';
+    static readonly PAGE_NOTIFICATIONS_SHOWMUTE_KEY = 'page_notifications_show_mute';
+    static readonly PAGE_NOTIFICATIONS_SHOWHIDE_KEY = 'page_notifications_show_hide';
+
     static isEnabled = new ObservableValue<boolean>(true);
     static domainExclusions = new ObservableSet<string>();
     static browserNotificationsEnabled = new ObservableValue<boolean>(true);
     static pageNotificationsEnabled = new ObservableValue<boolean>(true);
+
+    //in page options
+    static pageNotificationsAutoHideTime = new ObservableValue<number>(5);
+    static pageNotificationsDismissTime = new ObservableValue<number>(1);
+    static pageNotificationsShowMore = new ObservableValue<boolean>(true);
+    static pageNotificationsShowMute = new ObservableValue<boolean>(true);
+    static pageNotificationsShowHide = new ObservableValue<boolean>(true);
 
     // Injected storage backends  (TODO: do we need both?)
     // Sync is used to share data across browsers if logged in, e.g. plugin settings
@@ -37,27 +50,54 @@ class Preferences {
     static async initDefaults(preferenceStore: IStorageBackend, localStore: IStorageBackend) {
         console.log('Defaulting settings');
         this.setBackingStores(preferenceStore, localStore);
+
         // Reset callbacks
         this.isEnabled.removeAllListeners();
         this.domainExclusions.removeAllListeners();
         this.browserNotificationsEnabled.removeAllListeners();
         this.pageNotificationsEnabled.removeAllListeners();
+        this.pageNotificationsAutoHideTime.removeAllListeners();
+        this.pageNotificationsDismissTime.removeAllListeners();
+        this.pageNotificationsShowMore.removeAllListeners();
+        this.pageNotificationsShowMute.removeAllListeners();
+        this.pageNotificationsShowHide.removeAllListeners();
 
         // Set up default callbacks
+
         this.isEnabled.addListener(this.IS_ENABLED_KEY, (result: boolean) => {
-            void this.setPreference(Preferences.IS_ENABLED_KEY, result);
+            this.setPreference(Preferences.IS_ENABLED_KEY, result);
         });
 
         this.domainExclusions.addListener(this.DOMAIN_EXCLUSIONS_KEY, (result: string[]) => {
-            void this.setPreference(Preferences.DOMAIN_EXCLUSIONS_KEY, result);
+            this.setPreference(Preferences.DOMAIN_EXCLUSIONS_KEY, result);
         });
 
         this.browserNotificationsEnabled.addListener(this.BROWSER_NOTIFICATIONS_ENABLED_KEY, (result: boolean) => {
-            void this.setPreference(Preferences.BROWSER_NOTIFICATIONS_ENABLED_KEY, result);
+            this.setPreference(Preferences.BROWSER_NOTIFICATIONS_ENABLED_KEY, result);
         });
 
         this.pageNotificationsEnabled.addListener(this.PAGE_NOTIFICATIONS_ENABLED_KEY, (result: boolean) => {
-            void this.setPreference(Preferences.PAGE_NOTIFICATIONS_ENABLED_KEY, result);
+            this.setPreference(Preferences.PAGE_NOTIFICATIONS_ENABLED_KEY, result);
+        });
+
+        this.pageNotificationsAutoHideTime.addListener(this.PAGE_NOTIFICATIONS_AUTOHIDETIME_KEY, (result: number) => {
+            this.setPreference(Preferences.PAGE_NOTIFICATIONS_AUTOHIDETIME_KEY, result);
+        });
+
+        this.pageNotificationsDismissTime.addListener(this.PAGE_NOTIFICATIONS_DISMISSTIME_KEY, (result: number) => {
+            this.setPreference(Preferences.PAGE_NOTIFICATIONS_DISMISSTIME_KEY, result);
+        });
+
+        this.pageNotificationsShowMore.addListener(this.PAGE_NOTIFICATIONS_SHOWMORE_KEY, (result: boolean) => {
+            this.setPreference(Preferences.PAGE_NOTIFICATIONS_SHOWMORE_KEY, result);
+        });
+
+        this.pageNotificationsShowMute.addListener(this.PAGE_NOTIFICATIONS_SHOWMUTE_KEY, (result: boolean) => {
+            this.setPreference(Preferences.PAGE_NOTIFICATIONS_SHOWMUTE_KEY, result);
+        });
+
+        this.pageNotificationsShowHide.addListener(this.PAGE_NOTIFICATIONS_SHOWHIDE_KEY, (result: boolean) => {
+            this.setPreference(Preferences.PAGE_NOTIFICATIONS_SHOWHIDE_KEY, result);
         });
 
         // Attempt preference retrieval
@@ -89,6 +129,41 @@ class Preferences {
         } else {
             this.pageNotificationsEnabled.value = true;
         }
+
+        const rawPageNotificationsAutoHide = await this.getPreference(this.PAGE_NOTIFICATIONS_AUTOHIDETIME_KEY);
+        if (typeof rawPageNotificationsAutoHide === 'number') {
+            this.pageNotificationsAutoHideTime.value = rawPageNotificationsAutoHide;
+        } else {
+            this.pageNotificationsAutoHideTime.value = 5;
+        }
+
+        const rawPageNotificationsDismissTime = await this.getPreference(this.PAGE_NOTIFICATIONS_DISMISSTIME_KEY);
+        if (typeof rawPageNotificationsDismissTime === 'number') {
+            this.pageNotificationsDismissTime.value = rawPageNotificationsDismissTime;
+        } else {
+            this.pageNotificationsDismissTime.value = 1;
+        }
+
+        const rawrawpageNotificationsShowMore = await this.getPreference(this.PAGE_NOTIFICATIONS_SHOWMORE_KEY);
+        if (typeof rawrawpageNotificationsShowMore === 'boolean') {
+            this.pageNotificationsShowMore.value = rawrawpageNotificationsShowMore;
+        } else {
+            this.pageNotificationsShowMore.value = true;
+        }
+
+        const rawpageNotificationsShowMute = await this.getPreference(this.PAGE_NOTIFICATIONS_SHOWMUTE_KEY);
+        if (typeof rawpageNotificationsShowMute === 'boolean') {
+            this.pageNotificationsShowMute.value = rawpageNotificationsShowMute;
+        } else {
+            this.pageNotificationsShowMute.value = true;
+        }
+
+        const rawpageNotificationsShowHide = await this.getPreference(this.PAGE_NOTIFICATIONS_SHOWHIDE_KEY);
+        if (typeof rawpageNotificationsShowHide === 'boolean') {
+            this.pageNotificationsShowHide.value = rawpageNotificationsShowHide;
+        } else {
+            this.pageNotificationsShowHide.value = true;
+        }
     }
 
     public static dump(): void {
@@ -96,7 +171,12 @@ class Preferences {
             `IsEnabled = ${Preferences.isEnabled.toString()}, ` +
             `DomainExclusions = ${Preferences.domainExclusions.toString()}, ` +
             `BrowserNotificationsEnabled = ${Preferences.browserNotificationsEnabled.toString()}, ` +
-            `PageNotificationsEnabled = ${Preferences.pageNotificationsEnabled.toString()}`;
+            `PageNotificationsEnabled = ${Preferences.pageNotificationsEnabled.toString()}, ` +
+            `PageNotificationsAutoHideTime = ${Preferences.pageNotificationsAutoHideTime.toString()}, ` +
+            `PageNotificationsDismissTime = ${Preferences.pageNotificationsDismissTime.toString()}, ` +
+            `pageNotificationsShowMore = ${Preferences.pageNotificationsShowMore.toString()}, ` +
+            `pageNotificationsShowMute = ${Preferences.pageNotificationsShowMute.toString()}, ` +
+            `pageNotificationsShowHide = ${Preferences.pageNotificationsShowHide.toString()}`;
         console.log(msg);
     }
 

--- a/src/storage/browser/browser-sync-storage.ts
+++ b/src/storage/browser/browser-sync-storage.ts
@@ -17,7 +17,7 @@ class BrowserSyncStorage implements IStorageBackend {
         try {
             if (currentValue != value) {
                 const toStore = JSON.stringify(value);
-                if (this.checkQue()) {
+                if (this.checkQueue()) {
                     this.buffer.set(key, toStore);
 
                     console.log(`BrowserSyncStorage.set Added to buffer: ${key} = ${toStore}`);
@@ -83,7 +83,7 @@ class BrowserSyncStorage implements IStorageBackend {
     }
 
     async remove(key: string): Promise<void> {
-        if (this.checkQue()) {
+        if (this.checkQueue()) {
             this.buffer.delete(key);
             this.removals.push(key);
 
@@ -133,7 +133,7 @@ class BrowserSyncStorage implements IStorageBackend {
         }, delay);
     }
 
-    private checkQue(): boolean {
+    private checkQueue(): boolean {
         const now = Date.now();
 
         this.timestamps.add(now);

--- a/src/storage/browser/browser-sync-storage.ts
+++ b/src/storage/browser/browser-sync-storage.ts
@@ -3,18 +3,39 @@ import getBrowserLastError from '@/utils/helpers/get-browser-last-error';
 import browser from 'webextension-polyfill';
 
 class BrowserSyncStorage implements IStorageBackend {
+    private buffer = new Map<string, unknown>();
+    private removals: string[] = [];
+    private flushTimeout: NodeJS.Timeout | null = null;
+    private timestamps = new Set<number>();
+
     /**
      * Stores a value under the given key in browser.storage.sync.
      * The value is JSON-stringified first.
      */
     async set(key: string, value: unknown): Promise<void> {
-        const toStore = JSON.stringify(value);
+        const currentValue = await this.get(key);
         try {
-            await browser.storage.sync.set({ [key]: toStore });
-            console.log(`BrowserSyncStorage.set: ${key} = ${toStore}`);
+            if (currentValue != value) {
+                const toStore = JSON.stringify(value);
+                if (this.checkQue()) {
+                    this.buffer.set(key, toStore);
+
+                    console.log(`BrowserSyncStorage.set Added to buffer: ${key} = ${toStore}`);
+
+                    this.scheduleSync();
+                } else {
+                    await browser.storage.sync.set({ [key]: toStore });
+                    console.log(`BrowserSyncStorage.set: ${key} = ${toStore}`);
+                    return;
+                }
+            } else {
+                console.log(`BrowserSyncStorage.set: Value is unchanged`);
+            }
         } catch (_error) {
             throw getBrowserLastError();
         }
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        await new Promise(() => {});
     }
 
     /**
@@ -23,8 +44,16 @@ class BrowserSyncStorage implements IStorageBackend {
      */
     async get(key: string): Promise<unknown> {
         try {
-            const result = await browser.storage.sync.get(key);
-            const rawValue: unknown = result[key];
+            let rawValue: unknown;
+            if (this.buffer.has(key)) {
+                rawValue = await new Promise(() => {
+                    return this.buffer.get(key);
+                });
+            } else {
+                const result = await browser.storage.sync.get(key);
+                rawValue = result[key];
+            }
+
             console.log('Raw value', rawValue, typeof rawValue);
 
             if (rawValue === undefined || rawValue === null) {
@@ -53,16 +82,69 @@ class BrowserSyncStorage implements IStorageBackend {
         }
     }
 
-    /**
-     * Removes the given key from browser.storage.sync.
-     */
     async remove(key: string): Promise<void> {
-        try {
-            await browser.storage.sync.remove(key);
-            console.log(`BrowserSyncStorage.remove: ${key}`);
-        } catch (_error) {
-            throw getBrowserLastError();
+        if (this.checkQue()) {
+            this.buffer.delete(key);
+            this.removals.push(key);
+
+            this.scheduleSync();
+        } else {
+            try {
+                await browser.storage.sync.remove(key);
+                console.log(`BrowserSyncStorage.remove: ${key}`);
+            } catch (_error) {
+                throw getBrowserLastError();
+            }
+            return;
         }
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        await new Promise(() => {});
+    }
+
+    private scheduleSync(delay = 1000): void {
+        if (this.flushTimeout) clearTimeout(this.flushTimeout);
+        this.flushTimeout = setTimeout(() => {
+            (async () => {
+                if (this.buffer.size > 0) {
+                    const toSave = { ...Object.fromEntries(this.buffer) };
+                    try {
+                        await browser.storage.sync.set(toSave);
+
+                        console.log('sync to storage.sync.set:', toSave);
+                    } catch (err) {
+                        console.error('Failed to sync to storage.sync.set:', err);
+                        throw getBrowserLastError();
+                    }
+                }
+                if (this.removals.length > 0) {
+                    const toRemove = [...this.removals];
+                    this.removals = [];
+                    try {
+                        await browser.storage.sync.remove(toRemove);
+
+                        console.log('sync to storage.sync.remove:', toRemove);
+                    } catch (err) {
+                        console.error('Failed to sync to storage.sync.remove:', err);
+                        throw getBrowserLastError();
+                    }
+                }
+                this.buffer.clear();
+            })();
+        }, delay);
+    }
+
+    private checkQue(): boolean {
+        const now = Date.now();
+
+        this.timestamps.add(now);
+
+        for (const ts of this.timestamps) {
+            if (ts + 60 * 1000 < now) {
+                this.timestamps.delete(ts);
+            }
+        }
+
+        return this.timestamps.size > 10;
     }
 }
 

--- a/src/storage/istorage-backend.ts
+++ b/src/storage/istorage-backend.ts
@@ -3,3 +3,16 @@ export interface IStorageBackend {
     get(key: string): Promise<unknown>;
     remove?(key: string): Promise<void>;
 }
+
+/*
+export interface IStorageSyncBackend {
+    buffer: Map<string, unknown>;
+    removals: string[];
+    flushTimeout: NodeJS.Timeout | null;
+
+    set(key: string, value: unknown): Promise<void>;
+    get(key: string): Promise<unknown>;
+    remove?(key: string): Promise<void>;
+    scheduleSync(delay: number): void;
+}
+*/

--- a/src/storage/istorage-backend.ts
+++ b/src/storage/istorage-backend.ts
@@ -3,16 +3,3 @@ export interface IStorageBackend {
     get(key: string): Promise<unknown>;
     remove?(key: string): Promise<void>;
 }
-
-/*
-export interface IStorageSyncBackend {
-    buffer: Map<string, unknown>;
-    removals: string[];
-    flushTimeout: NodeJS.Timeout | null;
-
-    set(key: string, value: unknown): Promise<void>;
-    get(key: string): Promise<unknown>;
-    remove?(key: string): Promise<void>;
-    scheduleSync(delay: number): void;
-}
-*/

--- a/src/ui/inpagenotification/Inspagenotification.tsx
+++ b/src/ui/inpagenotification/Inspagenotification.tsx
@@ -22,7 +22,7 @@ export interface IInPageNotificationPageOptions {
 }
 
 export interface IInPageNotificationPageMenu {
-    pageReferance: React.RefObject<HTMLParagraphElement | null>;
+    pageReference: React.RefObject<HTMLParagraphElement | null>;
 }
 
 export interface IInPageNotificationMessage {
@@ -42,15 +42,15 @@ export interface IInPageNotification {
 
 const InPageNotificationPageMenu = ({
     page,
-    pageReferance,
+    pageReference,
     options,
 }: IInPageNotificationPage & IInPageNotificationPageMenu & IInPageNotificationPageOptions) => {
     return (
         <>
             <div className="page-menu">
                 {options.showMore && <InPageNotificationPageMore />}
-                {options.showMute && <InPageNotificationPageMute page={page} pageReferance={pageReferance} />}
-                {options.showHide && <InPageNotificationPageHide page={page} pageReferance={pageReferance} />}
+                {options.showMute && <InPageNotificationPageMute page={page} pageReference={pageReference} />}
+                {options.showHide && <InPageNotificationPageHide page={page} pageReference={pageReference} />}
             </div>
         </>
     );
@@ -78,7 +78,7 @@ const InPageNotificationPageMore = () => {
     );
 };
 
-const InPageNotificationPageMute = ({ page, pageReferance }: IInPageNotificationPage & IInPageNotificationPageMenu) => {
+const InPageNotificationPageMute = ({ page, pageReference }: IInPageNotificationPage & IInPageNotificationPageMenu) => {
     const mutePage = () => {
         const notifyUpdatePayload = {
             pageId: page.pageId,
@@ -90,8 +90,8 @@ const InPageNotificationPageMute = ({ page, pageReferance }: IInPageNotification
             payload: notifyUpdatePayload,
         });
 
-        if (pageReferance) {
-            pageReferance.current?.remove();
+        if (pageReference) {
+            pageReference.current?.remove();
         }
     };
     return (
@@ -103,7 +103,7 @@ const InPageNotificationPageMute = ({ page, pageReferance }: IInPageNotification
     );
 };
 
-const InPageNotificationPageHide = ({ page, pageReferance }: IInPageNotificationPage & IInPageNotificationPageMenu) => {
+const InPageNotificationPageHide = ({ page, pageReference }: IInPageNotificationPage & IInPageNotificationPageMenu) => {
     const hidePage = () => {
         const notifyUpdatePayload = {
             pageId: page.pageId,
@@ -115,8 +115,8 @@ const InPageNotificationPageHide = ({ page, pageReferance }: IInPageNotification
             payload: notifyUpdatePayload,
         });
 
-        if (pageReferance) {
-            pageReferance.current?.remove();
+        if (pageReference) {
+            pageReference.current?.remove();
         }
     };
     return (
@@ -152,7 +152,7 @@ const InPageNotificationPage = ({ page, options }: IInPageNotificationPage & IIn
     return (
         <>
             <div className="page" ref={componentReferance}>
-                <InPageNotificationPageMenu page={page} options={options} pageReferance={componentReferance} />
+                <InPageNotificationPageMenu page={page} options={options} pageReference={componentReferance} />
                 <InPageNotificationPageLink page={page} />
                 {options.showMore && <InPageNotificationPageInfo page={page} />}
             </div>

--- a/src/ui/options/Options.module.css
+++ b/src/ui/options/Options.module.css
@@ -160,3 +160,48 @@
 .toggleLabel input:checked + .toggleSlider::before {
     transform: translateX(22px);
 }
+
+.slidecontainer {
+  width: 100%;
+}
+
+.slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 25px;
+  background: #d3d3d3;
+  outline: none;
+  opacity: 0.7;
+  -webkit-transition: .2s;
+  transition: opacity .2s;
+}
+
+.slider:hover {
+  opacity: 1;
+}
+
+.slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 25px;
+  height: 25px;
+  background: #04AA6D;
+  cursor: pointer;
+}
+
+.slider::-moz-range-thumb {
+  width: 25px;
+  height: 25px;
+  background: #04AA6D;
+  cursor: pointer;
+}
+
+datalist {
+  display: flex;
+  justify-content: space-between;
+  writing-mode: lr;
+  width: 100%;
+  padding-left: 8px;
+  padding-right: 5px;
+}

--- a/src/ui/options/Options.module.css
+++ b/src/ui/options/Options.module.css
@@ -161,7 +161,7 @@
     transform: translateX(22px);
 }
 
-.slidecontainer {
+.sliderContainer {
   width: 100%;
 }
 

--- a/src/ui/options/Options.module.css
+++ b/src/ui/options/Options.module.css
@@ -197,7 +197,7 @@
   cursor: pointer;
 }
 
-datalist {
+.sliderDatalist {
   display: flex;
   justify-content: space-between;
   writing-mode: lr;

--- a/src/ui/options/Options.tsx
+++ b/src/ui/options/Options.tsx
@@ -1,5 +1,5 @@
 import useEffectOnce from '@/utils/hooks/use-effect-once';
-import React, { FormEvent, useState } from 'react';
+import React, { FormEvent, useState, ChangeEvent } from 'react';
 import { createRoot } from 'react-dom/client';
 import { getDomain } from 'tldts';
 import classNames from 'classnames';
@@ -24,6 +24,13 @@ const Options = () => {
                     setItems([...result])
                 );
                 setItems([...Preferences.domainExclusions.value]);
+
+                setInPageAutoHideTime(Preferences.pageNotificationsAutoHideTime.value);
+                setInPageDismissTime(Preferences.pageNotificationsDismissTime.value);
+
+                setInPageShowMore(Preferences.pageNotificationsShowMore.value);
+                setInPageShowMute(Preferences.pageNotificationsShowMute.value);
+                setInPageShowHide(Preferences.pageNotificationsShowHide.value);
             })
             .catch((error: unknown) => console.error('Failed to initialize preferences:', error));
 
@@ -53,6 +60,42 @@ const Options = () => {
     const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
         addItem();
+    };
+
+    const [inPageAutoHideTime, setInPageAutoHideTime] = useState(5);
+    const setInPageAutoHideTimeOnChange = (event: ChangeEvent<HTMLInputElement>) => {
+        setInPageAutoHideTime(Number(event.currentTarget.value));
+    };
+    const setInPageAutoHideTimeSave = () => {
+        Preferences.pageNotificationsAutoHideTime.value = Number(inPageAutoHideTime);
+    };
+
+    const [inPageDismissTime, setInPageDismissTime] = useState(1);
+    const setInPageDismissTimeOnChange = (event: ChangeEvent<HTMLInputElement>) => {
+        setInPageDismissTime(Number(event.currentTarget.value));
+        Preferences.pageNotificationsDismissTime.value = Number(event.currentTarget.value);
+    };
+
+    const setInPageDismissTimeSave = () => {
+        Preferences.pageNotificationsDismissTime.value = Number(inPageDismissTime);
+    };
+
+    const [inPageShowMore, setInPageShowMore] = useState(true);
+    const toggleInPageShowMore = () => {
+        setInPageShowMore(!inPageShowMore);
+        Preferences.pageNotificationsShowMore.value = Boolean(!inPageShowMore);
+    };
+
+    const [inPageShowMute, setInPageShowMute] = useState(true);
+    const toggleInPageShowMute = () => {
+        setInPageShowMute(!inPageShowMute);
+        Preferences.pageNotificationsShowMute.value = Boolean(!inPageShowMute);
+    };
+
+    const [inPageShowHide, setInPageShowHide] = useState(true);
+    const toggleInPageShowHide = () => {
+        setInPageShowHide(!inPageShowHide);
+        Preferences.pageNotificationsShowHide.value = Boolean(!inPageShowHide);
     };
 
     return (
@@ -102,6 +145,69 @@ const Options = () => {
                         <label className={styles.toggleLabel}>
                             <span>Enable Feature XYZ</span>
                             <input type="checkbox" />
+                            <span className={styles.toggleSlider} />
+                        </label>
+                    </div>
+                </div>
+
+                <div className={styles.settingsColumn}>
+                    <h2 className={styles.columnTitle}>{t('IN_PAGE_SETTINGS')}</h2>
+                    <div className={styles.settingsContainer}>
+                        <label className={styles.sliderLabel}>
+                            <span>{t('AUTOHIDE_LABEL', [inPageAutoHideTime.toString()])}</span>
+                            <div className={styles.slidecontainer}>
+                                <input
+                                    type="range"
+                                    value={inPageAutoHideTime}
+                                    min="0"
+                                    max="30"
+                                    onChange={setInPageAutoHideTimeOnChange}
+                                    onMouseUp={setInPageAutoHideTimeSave}
+                                    onTouchEnd={setInPageAutoHideTimeSave}
+                                    className={styles.slider}
+                                    list="autohide-data"
+                                />
+                                <datalist id="autohide-data">
+                                    <option value="0" label={t('OFF')}></option>
+                                    <option value="30" label={t('30')}></option>
+                                </datalist>
+                            </div>
+                        </label>
+
+                        <label className={styles.sliderLabel}>
+                            <span>{t('DISMISS_TIME_LABEL', [inPageDismissTime.toString()])}</span>
+                            <div className={styles.slidecontainer}>
+                                <input
+                                    type="range"
+                                    value={inPageDismissTime}
+                                    min="1"
+                                    max="48"
+                                    onChange={setInPageDismissTimeOnChange}
+                                    onMouseUp={setInPageDismissTimeSave}
+                                    onTouchEnd={setInPageDismissTimeSave}
+                                    className={styles.slider}
+                                    list="dismisstime-data"
+                                />
+                                <datalist id="dismisstime-data">
+                                    <option value="1" label="1"></option>
+                                    <option value="48" label="48"></option>
+                                </datalist>
+                            </div>
+                        </label>
+
+                        <label className={styles.toggleLabel}>
+                            <span>{t('SHOW_MORE_OPTION')}</span>
+                            <input type="checkbox" checked={inPageShowMore} onClick={toggleInPageShowMore} />
+                            <span className={styles.toggleSlider} />
+                        </label>
+                        <label className={styles.toggleLabel}>
+                            <span>{t('SHOW_MUTE_OPTION')}</span>
+                            <input type="checkbox" checked={inPageShowMute} onClick={toggleInPageShowMute} />
+                            <span className={styles.toggleSlider} />
+                        </label>
+                        <label className={styles.toggleLabel}>
+                            <span>{t('SHOW_HIDE_OPTION')}</span>
+                            <input type="checkbox" checked={inPageShowHide} onClick={toggleInPageShowHide} />
                             <span className={styles.toggleSlider} />
                         </label>
                     </div>

--- a/src/ui/options/Options.tsx
+++ b/src/ui/options/Options.tsx
@@ -167,7 +167,7 @@ const Options = () => {
                                     className={styles.slider}
                                     list="autohide-data"
                                 />
-                                <datalist id="autohide-data">
+                                <datalist className={styles.sliderDatalist} id="autohide-data">
                                     <option value="0" label={t('OFF')}></option>
                                     <option value="30" label={t('30')}></option>
                                 </datalist>
@@ -188,7 +188,7 @@ const Options = () => {
                                     className={styles.slider}
                                     list="dismisstime-data"
                                 />
-                                <datalist id="dismisstime-data">
+                                <datalist className={styles.sliderDatalist} id="dismisstime-data">
                                     <option value="1" label="1"></option>
                                     <option value="48" label="48"></option>
                                 </datalist>

--- a/src/utils/helpers/localized.ts
+++ b/src/utils/helpers/localized.ts
@@ -2,8 +2,6 @@ import { useCallback } from 'react';
 
 export function useI18n() {
     const t = useCallback((key: string, substitutions?: string | string[]) => {
-        console.log('useCallback: ', key);
-
         const i18n = chrome.i18n || browser.i18n;
         const message = i18n.getMessage(key, substitutions);
 
@@ -11,6 +9,7 @@ export function useI18n() {
             return message;
         }
 
+        console.log('useI18n: translation missing', key);
         return key;
     }, []);
 


### PR DESCRIPTION
Changed: browser sync storage as there is a limit to how manny packages you can send to the cloud (this is done with a timestamp counter) > 10 curently. if threasshold is reached it will delay send and send it one second later. further "adds" are added to the same "batch" and time is reset by 1 sec Changed so that it wont .set of value already equal to .get

<img width="385" height="378" alt="image" src="https://github.com/user-attachments/assets/7c74ec8d-2b05-4df3-a1f8-9e16b5f71889" />

----
- [x] The target of this PR is the `main` branch.
- [x] No commits are missing from forked base branch (e.g. modified main branch instead of dev)
- [x] You have squashed commits that might be considered: 'noisy' or partial, e.g. not candidates for cherry picking
- [x] All test pass, run `npm test`
- [x] The code is formatted, run `npm run format`
- [x] You have updated or added test cases, as/if required
- [x] You have installed and tried out the plugin in a supported browser
